### PR TITLE
fixed issue with Jack is required to support java 8 language features

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,6 +27,9 @@ android {
         
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "bz.rxla.sytody"
+        jackOptions {
+            enabled true
+        }
     }
 
     buildTypes {


### PR DESCRIPTION
Hi Erick,

Thank you for creating the project. 

I found the error blow when trying to build it in flutter, and Enabling Jackopiton seems to fix the issue.

FAILURE: Build failed with an exception.

* Where:
Build file 'A:\Personal\Dev\Git\sytody\android\build.gradle' line: 20

* What went wrong:
A problem occurred evaluating root project 'android'.
> A problem occurred configuring project ':app'.
   > Jack is required to support java 8 language features. Either enable Jack or remove sourceCompatibility JavaVersion.VERSION_1_8.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.


